### PR TITLE
adding in output for EKS workers security group id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -73,6 +73,11 @@ output "worker_iam_role_arn" {
   value       = module.eks.worker_iam_role_arn
 }
 
+output "worker_iam_role_name" {
+  description = "Default IAM role name for EKS worker groups"
+  value       = module.eks.worker_iam_role_name
+}
+
 output "ocean_cluster_id" {
   description = "The ID of the Ocean cluster"
   value       = spotinst_ocean_aws.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -82,3 +82,8 @@ output "ocean_controller_id" {
   description = "The ID of the Ocean controller"
   value       = spotinst_ocean_aws.this.controller_id
 }
+
+output "worker_node_security_group_id" {
+  description = "The Security Group ID for the EKS workers"
+  value       = module.eks.worker_security_group_id
+}


### PR DESCRIPTION
We need to make the EKS worker security group ID available to our terraform workspace. This is needed to be added into our Virtual Node Groups as part fo the ocean cluster.