### PR TITLE
bump eks module to 17 to fix windows ami issue.

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 16.0"
+  version = "~> 17.0"
 
   cluster_name                                       = local.cluster_name
   subnets                                            = local.subnets


### PR DESCRIPTION
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1410 causes Windows AMI errors on deployment, this is fixed in v17.0.3