### PR TITLE
SRE-1524 Forking 1.5.0 to add configuration of autoscaler from ocean-eks module

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -2,6 +2,15 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 17.0"
 
+  autoscaler_cooldown                                = var.autoscaler_cooldown
+  autoscaler_cpu_per_unit                            = var.autoscaler_cpu_per_unit
+  autoscaler_gpu_per_unit                            = var.autoscaler_gpu_per_unit
+  autoscaler_max_memory_gib                          = var.autoscaler_max_memory_gib
+  autoscaler_max_scale_down_percentage               = var.autoscaler_max_scale_down_percentage
+  autoscaler_max_vcpu                                = var.autoscaler_max_vcpu
+  autoscaler_memory_per_unit                         = var.autoscaler_memory_per_unit
+  autoscaler_num_of_units                            = var.autoscaler_num_of_units
+  enable_autoscaler                                  = var.enable_autoscaler
   attach_worker_cni_policy                           = var.attach_worker_cni_policy
   aws_auth_additional_labels                         = var.aws_auth_additional_labels
   cluster_create_endpoint_private_access_sg_rule     = var.cluster_create_endpoint_private_access_sg_rule

--- a/ocean.tf
+++ b/ocean.tf
@@ -39,8 +39,26 @@ EOF
   }
 
   autoscaler {
-    autoscale_is_enabled     = true
-    autoscale_is_auto_config = true
+    autoscale_is_enabled     = var.enable_autoscaler
+    autoscale_is_auto_config = var.autoscale_is_auto_config
+    auto_headroom_percentage = var.autoscale_is_auto_config ? var.auto_headroom_percentage : null
+    autoscale_cooldown       = var.enable_autoscaler ? var.autoscaler_cooldown : null
+
+    autoscale_headroom {
+      cpu_per_unit    = var.enable_autoscaler ? var.autoscaler_cpu_per_unit : null
+      gpu_per_unit    = var.enable_autoscaler ? var.autoscaler_gpu_per_unit : null
+      memory_per_unit = var.enable_autoscaler ? var.autoscaler_memory_per_unit : null
+      num_of_units    = var.enable_autoscaler ? var.autoscaler_num_of_units : null
+    }
+
+    autoscale_down {
+      max_scale_down_percentage = var.enable_autoscaler ? var.autoscaler_max_scale_down_percentage : null
+    }
+
+    resource_limits {
+      max_vcpu       = var.enable_autoscaler ? var.autoscaler_max_vcpu : null
+      max_memory_gib = var.enable_autoscaler ? var.autoscaler_max_memory_gib : null
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -514,6 +514,73 @@ variable "spot_percentage" {
   default     = 100
 }
 
+variable "enable_autoscaler" {
+  type        = bool
+  description = "Enables/disables the Ocean Kubernetes Auto Scaler. Default is true"
+  default     = true
+}
+
+
+variable "autoscale_is_auto_config" {
+  type        = bool
+  description = "Enables/disables automatic configuration and optimization of headroom resources. Default is true"
+  default     = true
+}
+
+variable "auto_headroom_percentage" {
+  type        = number
+  description = "Sets the auto headroom percentage (a number in the range [0, 200]) which controls the percentage of headroom from the cluster. Relevant only when autoscale_is_auto_config toggled on"
+  default     = null
+}
+
+variable "autoscale_cooldown" {
+  type        = number
+  description = "Sets cooldown period between scaling actions"
+  default     = null
+}
+
+variable "autoscaler_cpu_per_unit" {
+  type        = number
+  description = "Configures the number of CPUs to allocate the headroom. CPUs are denoted in millicores, where 1000 millicores = 1 vCPU"
+  default     = null
+}
+
+variable "autoscaler_gpu_per_unit" {
+  type        = number
+  description = "Configures the number of GPUs to allocate the headroom"
+  default     = null
+}
+
+variable "autoscaler_memory_per_unit" {
+  type        = number
+  description = "Configures the amount of memory (MB) to allocate the headroom"
+  default     = null
+}
+
+variable "autoscaler_num_of_units" {
+  type        = number
+  description = "Sets the number of units to retain as headroom, where each unit has the defined headroom CPU and memory."
+  default     = null
+}
+
+variable "autoscaler_max_scale_down_percentage" {
+  type        = number
+  description = "Sets the maximum % to scale-down. Number between 1-100"
+  default     = null
+}
+
+variable "autoscaler_max_vcpu" {
+  type        = number
+  description = "Sets the maximum cpu in vCPU units that can be allocated to the cluster."
+  default     = null
+}
+
+variable "autoscaler_max_memory_gib" {
+  type        = number
+  description = "Sets the maximum memory in GiB units that can be allocated to the cluster"
+  default     = null
+}
+
 // endregion
 
 // region spotinst/ocean-controller


### PR DESCRIPTION
Currently ocean-eks module defaults autoscaler configuration to automatic configuration when enabled. The autoscaler is also enabled by default.

The purpose of this PR is to add some flexibility to spotinst/ocean-eks to make use of the ability to configure autoscaler available in the [spotinst_ocean_aws](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws) resource.

This gives us infrastructure designers and engineers using spotinst to develop ocean clusters configurable for autoscalers' headroom, cooldown and resource limits.


```
autoscaler {
  autoscale_is_enabled     = true
  autoscale_is_auto_config = true
  auto_headroom_percentage = 100
  autoscale_cooldown       = 300

  autoscale_headroom {
    cpu_per_unit    = 1024
    gpu_per_unit    = 0
    memory_per_unit = 512
    num_of_units    = 2
  }

  autoscale_down {
    max_scale_down_percentage = 60
  }

  resource_limits {
    max_vcpu       = 1024
    max_memory_gib = 1500
  }
}
```