### PR TITLE
Allow overridable userdata for worker nodes

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -34,6 +34,12 @@ locals {
     ? var.cluster_identifier
     : module.eks.cluster_id
   )
+
+  userdata = var.worker_userdata != null ? var.worker_userdata : <<-EOF
+    #!/bin/bash
+    set -o xtrace
+    /etc/eks/bootstrap.sh ${local.cluster_name}
+EOF
 }
 
 resource "random_string" "suffix" {

--- a/ocean.tf
+++ b/ocean.tf
@@ -17,11 +17,7 @@ resource "spotinst_ocean_aws" "this" {
   blacklist                   = var.blacklist
   spot_percentage             = var.spot_percentage
   iam_instance_profile        = element(concat(module.eks.worker_iam_instance_profile_arns, [""]), 0)
-  user_data                   = <<-EOF
-    #!/bin/bash
-    set -o xtrace
-    /etc/eks/bootstrap.sh ${local.cluster_name}
-EOF
+  user_data                   = local.userdata
 
   security_groups = flatten([
     module.eks.worker_security_group_id,

--- a/variables.tf
+++ b/variables.tf
@@ -454,6 +454,12 @@ variable "ami_id" {
   default     = null
 }
 
+variable "worker_userdata" {
+  type = string
+  default = null
+  description = "Userdata to pass to worker node instances. If none is provided, a default Linux eks bootstrap script is used."
+}
+
 variable "root_volume_size" {
   type        = string
   description = "The size (in GiB) to allocate for the root volume"

--- a/variables.tf
+++ b/variables.tf
@@ -455,8 +455,8 @@ variable "ami_id" {
 }
 
 variable "worker_userdata" {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Userdata to pass to worker node instances. If none is provided, a default Linux eks bootstrap script is used."
 }
 


### PR DESCRIPTION
Enable user data to be passed to the module for worker nodes. 

A use-case where this is necessary is when the worker nodes are configured as Windows, the nodes' startup fails with the default Linux script (when a powershell script needs to be passed).