### PR TITLE
fix: ignore changes on desired_capacity

### DIFF
--- a/ocean.tf
+++ b/ocean.tf
@@ -97,6 +97,13 @@ resource "spotinst_ocean_aws" "this" {
       value = tags.value
     }
   }
+
+  # Prevent Capacity from changing during updates
+  lifecycle {
+    ignore_changes = [
+      desired_capacity
+    ]
+  }
 }
 
 module "ocean-controller" {


### PR DESCRIPTION
The capacity of an Ocean cluster is meant to vary over time (since
Ocean acts as a cluster autoscaler).
For this reason, if a user re-applies their Terraform script, the
cluster should not revert back to the desired_capacity set in the
Terraform script. This would disrupt the workloads of the user.

This behavior is taken from the ocean-aws-k8s module:
https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s/blob/main/ocean.tf#L109
